### PR TITLE
Add return type to push, update and remove

### DIFF
--- a/sources/CamembertModel.swift
+++ b/sources/CamembertModel.swift
@@ -22,9 +22,13 @@ class CamembertModel :NSObject {
         Camembert.initDataBase(DataAccess.access.nameDataBase!)
     }
     
-    func push() {
+    enum OperationResult{
+        case Success, Error_DuplicatedID, Error_NoRecordFoundWithID, Error_GeneralFailure
+    }
+    
+    func push() -> OperationResult{
         if self.id != nil {
-            return Void()
+            return OperationResult.Error_DuplicatedID
         }
         CamembertModel.openConnection()
         var requestPush = "INSERT INTO " + self.nameTable + " ("
@@ -49,14 +53,19 @@ class CamembertModel :NSObject {
             default: requestPush += ", "
             }
         }
-        camembertExecSqlite3(UnsafeMutablePointer<Void>(DataAccess.access.dataAccess),
+        let result = camembertExecSqlite3(UnsafeMutablePointer<Void>(DataAccess.access.dataAccess),
             requestPush.cStringUsingEncoding(NSUTF8StringEncoding)!)
         self.id = Int(sqlite3_last_insert_rowid(DataAccess.access.dataAccess))
+        var opResult: OperationResult = OperationResult.Success
+        if !result{
+            opResult = OperationResult.Error_GeneralFailure
+        }
+        return opResult
     }
     
-    func update() {
+    func update() -> OperationResult{
         if self.id == -1 {
-            return Void()
+            return OperationResult.Error_NoRecordFoundWithID
         }
         CamembertModel.openConnection()
         var requestUpdate :String = "UPDATE \(self.nameTable) SET "
@@ -74,20 +83,29 @@ class CamembertModel :NSObject {
             default: requestUpdate += ", "
             }
         }        
-        camembertExecSqlite3(UnsafeMutablePointer<Void>(DataAccess.access.dataAccess),
+        let result = camembertExecSqlite3(UnsafeMutablePointer<Void>(DataAccess.access.dataAccess),
             requestUpdate.cStringUsingEncoding(NSUTF8StringEncoding)!)
+        var opResult = OperationResult.Success
+        if !result{
+            opResult = OperationResult.Error_GeneralFailure
+        }
+        return opResult;
     }
     
-    func remove() {
+    func remove() -> OperationResult {
         if self.id == nil {
-            return Void()
+            return OperationResult.Error_NoRecordFoundWithID;
         }
         CamembertModel.openConnection()
         var requestDelete :String = "DELETE FROM \(self.nameTable) WHERE id=\(self.id!)"
         
-        camembertExecSqlite3(UnsafeMutablePointer<Void>(DataAccess.access.dataAccess),
+        let result = camembertExecSqlite3(UnsafeMutablePointer<Void>(DataAccess.access.dataAccess),
             requestDelete.cStringUsingEncoding(NSUTF8StringEncoding)!)
         self.id = -1
+        if !result{
+            return OperationResult.Error_GeneralFailure
+        }
+        return OperationResult.Success
     }
     
     func getSchemaTable() -> [String]! {

--- a/sources/CamembertModel.swift
+++ b/sources/CamembertModel.swift
@@ -19,7 +19,11 @@ class CamembertModel :NSObject {
     
     private class func openConnection() {
         Camembert.closeDataBase()
-        Camembert.initDataBase(DataAccess.access.nameDataBase!)
+        if let dbFolder = DataAccess.access.DbPath {
+            Camembert.initDataBase(dbFolder, nameDatabase: DataAccess.access.nameDataBase!)
+        }else{
+            Camembert.initDataBase(DataAccess.access.nameDataBase!)
+        }
     }
     
     enum OperationResult{


### PR DESCRIPTION
Since you are checking for “SQLITE_OK” in camembertExecSqlite3, I think
it is better to return a value to give the dev more flexibility so dev
can make sure data is handled correctly.
Description:
1. OperationResult.Success = Operation succeeded.
2. Error_DuplciatedID = Using push instead of update on a record
retrieved from the database.
3. Error_NoRecordFoundWithID = Using update instead of push, or using
remove on an object not yet pushed to database.
4. GeneralFailure = when camembertExecSqlite3 returns false.

I also added ability to choose which directory the database will be stored in.